### PR TITLE
Add brew cask install

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,22 +25,23 @@ It's a **Spotlight** plugin to display informations of unsupported images (**Web
 
 ### Installation
 
-2 choices : 
+3 choices : 
 
+- Via [Homebrew Cask](https://brew.sh/): `brew cask install qlimagesize`
+- Download manually the latest build from https://github.com/Nyx0uf/qlImageSize/releases/tag/1.6.1 and save it to the `~/Library/QuickLook` folder
 - Build from sources using Xcode. (just have to hit the build button)
-- L1cardo forked the project and offers a built version : https://github.com/L1cardo/qlImageSize
-
 
 ### Uninstall
 
-- Launch Terminal.app (in `/Applications/Utilities`)
-- Copy and paste the following line into the Terminal :
+- Via [Homebrew Cask](https://brew.sh/): `brew cask install qlimagesize`
+- Manually:
+  - Launch Terminal.app (in `/Applications/Utilities`)
+  - Copy and paste the following line into the Terminal :
 
-`sudo rm -rf "/Library/Application Support/qlimagesize" "~/Library/QuickLook/qlImageSize.qlgenerator" "~/Library/Spotlight/mdImageSize.mdimporter"`
+    `sudo rm -rf "/Library/Application Support/qlimagesize" "~/Library/QuickLook/qlImageSize.qlgenerator" "~/Library/Spotlight/mdImageSize.mdimporter"`
 
-- Press Enter.
-- Type your password and press Enter.
-
+  - Press Enter.
+  - Type your password and press Enter.
 
 ### Limitations
 

--- a/README.md
+++ b/README.md
@@ -28,20 +28,19 @@ It's a **Spotlight** plugin to display informations of unsupported images (**Web
 3 choices : 
 
 - Via [Homebrew Cask](https://brew.sh/): `brew cask install qlimagesize`
-- Download manually the latest build from https://github.com/Nyx0uf/qlImageSize/releases/tag/1.6.1 and save it to the `~/Library/QuickLook` folder
+- Download manually the latest build from https://github.com/Nyx0uf/qlImageSize/releases/latest and save it to the `~/Library/QuickLook` folder
 - Build from sources using Xcode. (just have to hit the build button)
 
 ### Uninstall
 
-- Via [Homebrew Cask](https://brew.sh/): `brew cask install qlimagesize`
+- Via [Homebrew Cask](https://brew.sh/): `brew cask uninstall qlimagesize`
 - Manually:
   - Launch Terminal.app (in `/Applications/Utilities`)
   - Copy and paste the following line into the Terminal :
 
-    `sudo rm -rf "/Library/Application Support/qlimagesize" "~/Library/QuickLook/qlImageSize.qlgenerator" "~/Library/Spotlight/mdImageSize.mdimporter"`
+    `rm -rf "~/Library/QuickLook/qlImageSize.qlgenerator" "~/Library/Spotlight/mdImageSize.mdimporter"`
 
   - Press Enter.
-  - Type your password and press Enter.
 
 ### Limitations
 


### PR DESCRIPTION
Since the cask formula has been added to homebrew-cask (https://github.com/Homebrew/homebrew-cask/pull/59162), here is an update for the README.md.

In the manual uninstallation steps, you're mentioning files that should be removed:
- `/Library/Application Support/qlimagesize`
- `~/Library/Spotlight/mdImageSize.mdimporter`

I didn't noticed that this files are created when using this plugin and it looks strange to me that a plugin write to `/Library/Application Support` (shouldn't it be `~/Library/Application Support`?).

Cask offer a "zap" mechanism to clean an application (ie: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/vlc.rb#L25-L33).

Maybe this folder should be added to the cask formula no?